### PR TITLE
Improve perfomance by setting `path_simplify_angle` of street line polygons

### DIFF
--- a/code/main.gd
+++ b/code/main.gd
@@ -61,6 +61,7 @@ func _on_download_completed(success, tile, current_x, current_y, offset_x, offse
 func render_geometries(tile, x, y, offset_x, offset_y):
 	var tile_node_current = Node3D.new()
 	tile_node_current.name = str(x + offset_x) + str(y + offset_y)
+	add_child(tile_node_current)
 
 	FLOOR_BUILDER.build_floor(tile_node_current, offset_x, offset_y)
 
@@ -174,7 +175,6 @@ func render_geometries(tile, x, y, offset_x, offset_y):
 					0.5
 				)
 
-	add_child(tile_node_current)
 
 # _process needs an argument, even if its never used
 # gdlint:ignore = unused-argument

--- a/code/main.gd
+++ b/code/main.gd
@@ -10,7 +10,6 @@ const START_X = 34319
 const START_Y = 22950
 
 #DO NOT TOUCH!!!
-const MVT_READER = preload("res://addons/geo-tile-loader/vector_tile_loader.gd")
 const WEBSERVER = preload("res://src/webserver.gd")
 const CONSTANTS = preload("res://src/common/constants.gd")
 const POLYGON_VECTOR_CALCULATOR = preload("res://src/polygons/calculate_polygon_vectors.gd")
@@ -51,18 +50,15 @@ func _ready():
 	process_y = START_Y
 
 
-func _on_download_completed(success, current_x, current_y, offset_x, offset_y):
+func _on_download_completed(success, tile, current_x, current_y, offset_x, offset_y):
 	if success:
-		print("download successfull for: x=", current_x, ", ", current_y)
-		render_geometries(current_x, current_y, offset_x, offset_y)
+		print("download successful for: x=", current_x, ", ", current_y)
+		render_geometries(tile, current_x, current_y, offset_x, offset_y)
 	else:
 		print("Download failed or timed out.")
 
 
-func render_geometries(x, y, offset_x, offset_y):
-	var tilepath = "res://tiles/" + str(x) + str(y)
-	var tile = MVT_READER.load_tile(tilepath)
-
+func render_geometries(tile, x, y, offset_x, offset_y):
 	var tile_node_current = Node3D.new()
 	tile_node_current.name = str(x + offset_x) + str(y + offset_y)
 

--- a/code/main.gd
+++ b/code/main.gd
@@ -36,12 +36,9 @@ var steps_x = 0
 var steps_y = 0
 
 func _ready():
-#loading of initial 4*4 area
+	#loading of initial 4*4 area
 	for i in range(-2, 2, 1):
 		for j in range(-2, 2, 1):
-			var tile_node = Node3D.new()
-			tile_node.name = str(START_X + i) + str(START_Y + j)
-			add_child(tile_node)
 			var webserver = WEBSERVER.new()
 			add_child(webserver)
 			webserver.connect("download_completed", _on_download_completed)
@@ -66,8 +63,8 @@ func render_geometries(x, y, offset_x, offset_y):
 	var tilepath = "res://tiles/" + str(x) + str(y)
 	var tile = MVT_READER.load_tile(tilepath)
 
-	var current_tile_node_path = str(x) + str(y)
-	var tile_node_current = get_node(current_tile_node_path)
+	var tile_node_current = Node3D.new()
+	tile_node_current.name = str(x + offset_x) + str(y + offset_y)
 
 	FLOOR_BUILDER.build_floor(tile_node_current, offset_x, offset_y)
 
@@ -181,6 +178,8 @@ func render_geometries(x, y, offset_x, offset_y):
 					0.5
 				)
 
+	add_child(tile_node_current)
+
 # _process needs an argument, even if its never used
 # gdlint:ignore = unused-argument
 func _process(delta):
@@ -197,9 +196,6 @@ func _process(delta):
 
 		for i in range(-2, 2, 1):
 			var webserver = WEBSERVER.new()
-			var tile_node = Node3D.new()
-			add_child(tile_node)
-			tile_node.name = str(process_x) + str(process_y + i)
 			add_child(webserver)
 			webserver.connect("download_completed", _on_download_completed)
 			webserver.download_file(
@@ -224,9 +220,6 @@ func _process(delta):
 
 		for i in range(-2, 2, 1):
 			var webserver = WEBSERVER.new()
-			var tile_node = Node3D.new()
-			add_child(tile_node)
-			tile_node.name = str(process_x) + str(process_y + i)
 			add_child(webserver)
 			webserver.connect("download_completed", _on_download_completed)
 			webserver.download_file(
@@ -251,9 +244,6 @@ func _process(delta):
 
 		for i in range(-2, 2, 1):
 			var webserver = WEBSERVER.new()
-			var tile_node = Node3D.new()
-			add_child(tile_node)
-			tile_node.name = str(process_x + i) + str(process_y)
 			add_child(webserver)
 			webserver.connect("download_completed", _on_download_completed)
 			webserver.download_file(
@@ -278,9 +268,6 @@ func _process(delta):
 
 		for i in range(-2, 2, 1):
 			var webserver = WEBSERVER.new()
-			var tile_node = Node3D.new()
-			add_child(tile_node)
-			tile_node.name = str(process_x + i) + str(process_y)
 			add_child(webserver)
 			webserver.connect("download_completed", _on_download_completed)
 			webserver.download_file(

--- a/code/project.godot
+++ b/code/project.godot
@@ -10,7 +10,7 @@ config_version=5
 
 [application]
 
-config/name="Code"
+config/name="3D-OSM"
 run/main_scene="res://main.tscn"
 config/features=PackedStringArray("4.1", "Forward Plus")
 config/icon="res://icon.svg"

--- a/code/src/linestrings/build_linestrings.gd
+++ b/code/src/linestrings/build_linestrings.gd
@@ -29,7 +29,8 @@ static func generate_paths(path_points, caller_node, color, offset_x, offset_y, 
 
 		var polygon = CREATE_CSGPOLYGON3D.create_polygon(color, path_polygon)
 		polygon.mode = CSGPolygon3D.MODE_PATH
-		polygon.path_interval = 0.5
+		#polygon.path_interval = 0.5
+		polygon.path_simplify_angle = 3.0
 		polygon.use_collision = true
 		polygon.path_node = path3d.get_path()
 		caller_node.add_child(polygon)

--- a/code/src/webserver.gd
+++ b/code/src/webserver.gd
@@ -1,6 +1,6 @@
 extends Node
 
-signal download_completed(success, x, y, offset_x, offset_y)
+signal download_completed(success, tile, x, y, offset_x, offset_y)
 
 var current_x = 0
 var current_y = 0
@@ -16,9 +16,6 @@ func download_file(x, y, offset_x, offset_y):
 	add_child(http_request)
 
 	var download_http = "https://tiles.streets.gl/vector/16/" + str(x) + "/" + str(y)
-	var download_local = "res://tiles/" + str(x) + str(y)
-
-	http_request.download_file = download_local
 
 	http_request.request_completed.connect(_on_request_completed)
 	http_request.request(download_http)
@@ -27,6 +24,7 @@ func download_file(x, y, offset_x, offset_y):
 # gdlint:ignore = unused-argument
 func _on_request_completed(result, response_code, headers, body):
 	if response_code == 200:
-		emit_signal("download_completed", true, current_x, current_y, offset_x, offset_y)
+		var tile = MvtTile.read(body)
+		download_completed.emit(true, tile, current_x, current_y, offset_x, offset_y)
 	else:
-		emit_signal("download_completed", false, current_x, current_y, offset_x, offset_y)
+		download_completed.emit(false, null, current_x, current_y, offset_x, offset_y)


### PR DESCRIPTION
~Adding the node add the end of `render_geometries` solves all freezes!~

Found finally out which part is so slow. It's the `CSGPolygon3D`s created for the street lines. A major performance improvement can be achieved by setting `path_simplify_angle`.